### PR TITLE
Added check for ctx.obj to make this work with setup tools entry points

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -87,6 +87,9 @@ script like this:
     @click.option('--debug/--no-debug', default=False)
     @click.pass_context
     def cli(ctx, debug):
+        if ctx.obj is None:  # This is needed when we get here via a setup tools entry point
+            ctx.obj = {}
+
         ctx.obj['DEBUG'] = debug
 
     @cli.command()


### PR DESCRIPTION
Hi Markus,

Here is the tiny PR for the doc update to make the example in the docs work with entry points. I felt that it went better here than in setup tools integration.

Best
-Kaushik
